### PR TITLE
Remove traci prefix from sumo_cosimulation.py

### DIFF
--- a/opencda/co_simulation/sumo_integration/sumo_simulation.py
+++ b/opencda/co_simulation/sumo_integration/sumo_simulation.py
@@ -301,7 +301,7 @@ def _get_sumo_net(cfg_file):
     net_file = os.path.join(os.path.dirname(cfg_file), tag.get('value'))
     logging.debug('Reading net file: %s', net_file)
 
-    sumo_net = traci.sumolib.net.readNet(net_file)
+    sumo_net = sumolib.net.readNet(net_file)
     return sumo_net
 
 class SumoSimulation(object):


### PR DESCRIPTION
Line 304 of \opencda\co_simulation\sumo_integration\sumo_cosimulation.py uses a function from the sumolib package, but attempts to import sumolib from the traci package, which causes an error when running any cosimulation scenarios. Removing the traci import prefix solved the issue.